### PR TITLE
:bookmark: bump version 0.1.0 -> 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.2.0]
+
 ### Added
 
 - Added `acreate_from_gh_data`/`create_from_gh_data` manager methods to `Installation` and `Repository` models.
@@ -46,5 +48,6 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-github-app/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-github-app/compare/v0.2.0...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.1.0
+[0.2.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ Source = "https://github.com/joshuadavidthomas/django-github-app"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.1.0"
+current_version = "0.2.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_github_app/__init__.py
+++ b/src/django_github_app/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_github_app import __version__
 
 
 def test_version():
-    assert __version__ == "0.1.0"
+    assert __version__ == "0.2.0"


### PR DESCRIPTION
- `6b05aa7`: add migrations step to installation docs
- `8f23f04`: add manager methods for creating from GH API data (#9)
- `c726dce`: remove commented out dead test code
- `208ba8c`: add model method to `Installation` for retrieving accessible repos (#10)
- `75739d3`: rename test webhook view to avoid pytest collection
- `8e60e03`: create integration test plugin for pytest
- `b1c1af1`: add tests for integration plugin
- `7802aaf`: add Development section to README and update contribution guide (#12)
- `d0406ae`: add management command for importing an existing installation (#11)