### PR TITLE
:bookmark: bump version 0.3.0 -> 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.4.0]
+
 ### Added
 
 - Added `SyncWebhookView`, a synchronous counterpart to `AsyncWebhookView` for Django applications running under WSGI. Works with `SyncGitHubAPI` and synchronous event handlers to provide a fully synchronous workflow for processing GitHub webhooks.
@@ -70,8 +72,9 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-github-app/compare/v0.3.0...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-github-app/compare/v0.4.0...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.1.0
 [0.2.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.2.0
 [0.2.1]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.2.1
 [0.3.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.3.0
+[0.4.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ Source = "https://github.com/joshuadavidthomas/django-github-app"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.3.0"
+current_version = "0.4.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_github_app/__init__.py
+++ b/src/django_github_app/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_github_app import __version__
 
 
 def test_version():
-    assert __version__ == "0.3.0"
+    assert __version__ == "0.4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -313,7 +313,7 @@ wheels = [
 
 [[package]]
 name = "django-github-app"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
- `8adfc87`: add update uv lock to bump command
- `b33be0e`: get pr title from update commit message
- `12edffc`: bump lock file
- `80b621b`: allow for passing `Installation` instance to GitHub API clients (#30)
- `a7d7b68`: implement `SyncWebhookView` and refactor `GitHubRouter` for sync support (#31)
- `41a0f68`: rename internal webhook event modules (#32)
- `2f0fd9b`: add system check for sync/async webhook views (#33)
- `cb864c6`: add sync handlers for internal webhook events (#34)