### PR TITLE
:bookmark: bump version 0.5.0 -> 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.6.0]
+
 ### Added
 
 - Added support for Django 5.2.
@@ -94,10 +96,11 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-github-app/compare/v0.5.0...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-github-app/compare/v0.6.0...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.1.0
 [0.2.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.2.0
 [0.2.1]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.2.1
 [0.3.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.3.0
 [0.4.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.4.0
 [0.5.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.5.0
+[0.6.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.6.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # django-github-app
 
-[![PyPI](https://img.shields.io/pypi/v/django-github-app)](https://pypi.org/project/django-github-app/)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/django-github-app)
 <!-- [[[cog
 import subprocess
 import cog
@@ -9,8 +7,12 @@ import cog
 from noxfile import DJ_VERSIONS
 from noxfile import PY_VERSIONS
 
+cog.outl("[![PyPI](https://img.shields.io/pypi/v/django-github-app)](https://pypi.org/project/django-github-app/)")
+cog.outl("![PyPI - Python Version](https://img.shields.io/pypi/pyversions/django-github-app)")
 cog.outl(f"![Django Version](https://img.shields.io/badge/django-{'%20%7C%20'.join(DJ_VERSIONS)}-%2344B78B?labelColor=%23092E20)")
 ]]] -->
+[![PyPI](https://img.shields.io/pypi/v/django-github-app)](https://pypi.org/project/django-github-app/)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/django-github-app)
 ![Django Version](https://img.shields.io/badge/django-4.2%20%7C%205.1%20%7C%205.2%20%7C%20main-%2344B78B?labelColor=%23092E20)
 <!-- [[[end]]] -->
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ Source = "https://github.com/joshuadavidthomas/django-github-app"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.5.0"
+current_version = "0.6.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_github_app/__init__.py
+++ b/src/django_github_app/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_github_app import __version__
 
 
 def test_version():
-    assert __version__ == "0.5.0"
+    assert __version__ == "0.6.0"


### PR DESCRIPTION
- `a1564a9`: Update github.py (#41)
- `2a304b0`: [pre-commit.ci] pre-commit autoupdate (#40)
- `d03e23b`: Bump astral-sh/setup-uv from 3 to 4 in the gha group (#39)
- `8a5386e`: [pre-commit.ci] pre-commit autoupdate (#42)
- `8c92489`: [pre-commit.ci] pre-commit autoupdate (#43)
- `2dddab7`: [pre-commit.ci] pre-commit autoupdate (#44)
- `05c5942`: Bump astral-sh/setup-uv from 4 to 5 in the gha group (#45)
- `76cec22`: [pre-commit.ci] pre-commit autoupdate (#46)
- `4a2abed`: [pre-commit.ci] pre-commit autoupdate (#48)
- `9f752fc`: Add Django 5.2a1 to test matrix (#49)
- `5d70186`: Adjust Python minimum version for `main` Django (#51)
- `04fad34`: [pre-commit.ci] pre-commit autoupdate (#50)
- `4ad5f66`: [pre-commit.ci] pre-commit autoupdate (#52)
- `e941c8b`: [pre-commit.ci] pre-commit autoupdate (#53)
- `a8ce857`: [pre-commit.ci] pre-commit autoupdate (#54)
- `f4d7517`: Update Django 5.2 version to beta (#55)
- `778cdfe`: [pre-commit.ci] pre-commit autoupdate (#56)
- `f4bfea2`: [pre-commit.ci] pre-commit autoupdate (#57)
- `d7fd8ed`: [pre-commit.ci] pre-commit autoupdate (#58)
- `5e471fc`: [pre-commit.ci] pre-commit autoupdate (#59)
- `34be3ab`: add required `uv` version to pyproject.toml and regenerate `uv.lock` (#63)
- `8ed8df3`: convert `APP_ID` from settings to `int` to match GitHub event data (#62)
- `861dc19`: [pre-commit.ci] pre-commit autoupdate (#60)
- `cc7f60d`: update changelog
- `2bf73ea`: add support for Django 5.2 (#64)
- `a92d729`: drop support for Django 5.0 (#65)