### PR TITLE
:bookmark: bump version 0.6.0 -> 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.6.1]
+
 ### Fixed
 
 - Fixed excessive memory usage in `AsyncWebhookView` and `SyncWebhookView` caused by creating a new `GitHubRouter` instance on each request.
@@ -100,7 +102,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-github-app/compare/v0.6.0...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-github-app/compare/v0.6.1...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.1.0
 [0.2.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.2.0
 [0.2.1]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.2.1
@@ -108,3 +110,4 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [0.4.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.4.0
 [0.5.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.5.0
 [0.6.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.6.0
+[0.6.1]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.6.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ Source = "https://github.com/joshuadavidthomas/django-github-app"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.6.0"
+current_version = "0.6.1"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_github_app/__init__.py
+++ b/src/django_github_app/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -77,7 +77,7 @@ class TestGitHubRouter:
 
         assert len(router_ids) == 5
 
-    @pytest.mark.limit_memory("2.5MB")
+    @pytest.mark.limit_memory("3MB")
     def test_router_memory_stress_test(self):
         view_count = 50000
         views = []

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -77,26 +77,35 @@ class TestGitHubRouter:
 
         assert len(router_ids) == 5
 
-    @pytest.mark.limit_memory("3MB")
+    @pytest.mark.limit_memory("100KB")
+    @pytest.mark.xdist_group(group="memory_tests")
     def test_router_memory_stress_test(self):
-        view_count = 50000
+        view_count = 10000
         views = []
 
         for _ in range(view_count):
             view = View()
             views.append(view)
 
-        assert len(views) == view_count
-        assert all(view.router is views[0].router for view in views)
+        view1_router = views[0].router
 
-    @pytest.mark.limit_memory("4MB")
+        assert len(views) == view_count
+        assert all(view.router is view1_router for view in views)
+
+    @pytest.mark.limit_memory("1.5MB")
+    @pytest.mark.xdist_group(group="memory_tests")
+    @pytest.mark.skip(
+        "does not reliably allocate memory when run with other memory test"
+    )
     def test_router_memory_stress_test_legacy(self):
-        view_count = 50000
+        view_count = 10000
         views = []
 
         for _ in range(view_count):
             view = LegacyView()
             views.append(view)
 
+        view1_router = views[0].router
+
         assert len(views) == view_count
-        assert not all(view.router is views[0].router for view in views)
+        assert not all(view.router is view1_router for view in views)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_github_app import __version__
 
 
 def test_version():
-    assert __version__ == "0.6.0"
+    assert __version__ == "0.6.1"


### PR DESCRIPTION
- `ee3ce7b`: consolidate cog just recipe
- `45f1f8a`: add project using this blurb to README (#67)
- `9465d46`: update README to include `requester` arg to both concrete `GitHubAPI` classes (#68)
- `4d63707`: [pre-commit.ci] pre-commit autoupdate (#69)
- `69a7527`: Bump astral-sh/setup-uv from 5 to 6 in the gha group (#71)
- `59fe66f`: fix reference to moved cog recipe (#75)
- `af7fd99`: use `@pytest_asyncio.fixture` for all async fixtures and fix awaits (#76)
- `99e76c1`: fix memory issues by moving router instantiation out of view __init__ (#77)