### PR TITLE
:bookmark: bump version 0.6.1 -> 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.7.0]
+
 ### Added
 
 - Added `GITHUB_APP["LOG_ALL_EVENTS"]` setting to control webhook event logging. When `False`, only events with registered handlers are stored in the database.
@@ -107,7 +109,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-github-app/compare/v0.6.1...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-github-app/compare/v0.7.0...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.1.0
 [0.2.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.2.0
 [0.2.1]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.2.1
@@ -116,3 +118,4 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [0.5.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.5.0
 [0.6.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.6.0
 [0.6.1]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.6.1
+[0.7.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ Source = "https://github.com/joshuadavidthomas/django-github-app"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.6.1"
+current_version = "0.7.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_github_app/__init__.py
+++ b/src/django_github_app/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_github_app import __version__
 
 
 def test_version():
-    assert __version__ == "0.6.1"
+    assert __version__ == "0.7.0"


### PR DESCRIPTION
- `c1b976a`: [pre-commit.ci] pre-commit autoupdate (#79)
- `3ec76cc`: [pre-commit.ci] pre-commit autoupdate (#80)
- `f993e8d`: [pre-commit.ci] pre-commit autoupdate (#81)
- `7a745ab`: [pre-commit.ci] pre-commit autoupdate (#82)
- `776218a`: add `LOG_ALL_EVENTS` settings fo filter webhook events (#83)
- `4790b19`: change memory stress test memory to more realistic number (#85)
- `e9cf501`: add "clean up events" button to `EventLog` admin (#84)