### PR TITLE
:bookmark: bump version 0.8.0 -> 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Changed
+
+- Changed `installation_repositories` event handler to automatically create missing `Installation` models using new `get_or_create_from_event` method, eliminating the need for manual import when connecting to pre-existing GitHub App installations.
+
 ## [0.8.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Changed
 
-- Changed `installation_repositories` event handler to automatically create missing `Installation` models using new `get_or_create_from_event` method, eliminating the need for manual import when connecting to pre-existing GitHub App installations.
+- Changed `installation_repositories` internal event handlers to automatically create missing `Installation` models using new `(a)get_or_create_from_event` method, eliminating the need for manual import when connecting to pre-existing GitHub App installations.
 
 ## [0.8.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.9.0]
+
 ### Changed
 
 - Changed `installation_repositories` internal event handlers to automatically create missing `Installation` models using new `(a)get_or_create_from_event` method, eliminating the need for manual import when connecting to pre-existing GitHub App installations.
@@ -123,7 +125,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-github-app/compare/v0.8.0...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-github-app/compare/v0.9.0...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.1.0
 [0.2.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.2.0
 [0.2.1]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.2.1
@@ -134,3 +136,4 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [0.6.1]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.6.1
 [0.7.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.7.0
 [0.8.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.8.0
+[0.9.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.9.0

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Choose the appropriate setup method based on your situation:
 > django-github-app needs to create `Installation` and `Repository` models in your database to track where your GitHub App is installed. How this happens depends on your setup method:
 >
 > - **New GitHub App**: When you install the app for the first time, GitHub sends an `installation.created` webhook event. django-github-app automatically creates the necessary models when it receives this event.
-> - **Existing GitHub App**: If the app is already installed, no `installation.created` webhook event is sent. You must use the `github import-app` management command to manually create the models.
+> - **Existing GitHub App**: If the app is already installed, no `installation.created` webhook event is sent. django-github-app will automatically create the models when it receives the first `installation_repositories` event (e.g., when repositories are added/removed). Alternatively, you can use the `github import-app` management command to import the installation immediately.
 
 #### Create a New GitHub App
 
@@ -188,7 +188,9 @@ Choose the appropriate setup method based on your situation:
 
 #### Use an Existing GitHub App and Installation
 
-If your GitHub App is already installed on organizations/repositories, the `installation.created` webhook event won't be sent when you connect django-github-app to your existing app. In this case, you need to manually import the installation data.
+If your GitHub App is already installed on organizations/repositories, the `installation.created` webhook event won't be sent when you connect django-github-app to your existing app. django-github-app will automatically create the necessary models when it receives the first webhook event that includes installation data (such as `installation_repositories`).
+
+However, if you want to import the installation immediately without waiting for a webhook event, you can use the management command below.
 
 1. Collect your existing app and installation's information.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ Source = "https://github.com/joshuadavidthomas/django-github-app"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.8.0"
+current_version = "0.9.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_github_app/__init__.py
+++ b/src/django_github_app/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/src/django_github_app/models.py
+++ b/src/django_github_app/models.py
@@ -91,7 +91,9 @@ class InstallationManager(models.Manager["Installation"]):
         if installation is None and "installation" in event.data:
             app_id = event.data["installation"]["app_id"]
             if app_id == int(app_settings.APP_ID):
-                installation = await self.acreate_from_gh_data(event.data["installation"])
+                installation = await self.acreate_from_gh_data(
+                    event.data["installation"]
+                )
         return installation
 
     create_from_event = async_to_sync_method(acreate_from_event)

--- a/tests/events/test_installation.py
+++ b/tests/events/test_installation.py
@@ -148,3 +148,39 @@ def test_sync_installation_repositories(installation, create_event):
     assert Repository.objects.filter(
         repository_id=data["repositories_added"][0]["id"]
     ).exists()
+
+
+def test_sync_installation_repositories_creates_installation(
+    create_event, override_app_settings
+):
+    app_id = seq.next()
+    installation_id = seq.next()
+
+    data = {
+        "installation": {
+            "id": installation_id,
+            "app_id": app_id,
+            "account": {"login": "testorg", "type": "Organization"},
+        },
+        "repositories_removed": [],
+        "repositories_added": [
+            {
+                "id": seq.next(),
+                "node_id": "repo1234",
+                "full_name": "owner/repo",
+            }
+        ],
+    }
+    event = create_event("installation_repositories", delivery_id="1234", **data)
+
+    assert not Installation.objects.filter(installation_id=installation_id).exists()
+
+    with override_app_settings(APP_ID=str(app_id)):
+        sync_installation_repositories(event, None)
+
+    installation = Installation.objects.get(installation_id=installation_id)
+
+    assert installation.data == data["installation"]
+    assert Repository.objects.filter(
+        repository_id=data["repositories_added"][0]["id"], installation=installation
+    ).exists()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -328,6 +328,23 @@ class TestInstallationManager:
         assert result.installation_id == installation_id
         assert result.data == installation_data
 
+    def test_get_or_create_from_event_wrong_app_id(
+        self, create_event, override_app_settings
+    ):
+        installation_data = {
+            "id": seq.next(),
+            "app_id": seq.next(),
+        }
+        event = create_event(
+            "installation_repositories",
+            installation=installation_data,
+        )
+
+        with override_app_settings(APP_ID="999999"):
+            result = Installation.objects.get_or_create_from_event(event)
+
+        assert result is None
+
 
 class TestInstallationStatus:
     @pytest.mark.parametrize(

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_github_app import __version__
 
 
 def test_version():
-    assert __version__ == "0.8.0"
+    assert __version__ == "0.9.0"


### PR DESCRIPTION
- `1cd07e1`: Clarify new/existing GitHub App installation documentation (#99)
- `420a64d`: add `(a)get_or_create_from_event` method to `Installation` manager
- `b9d4fdb`: [pre-commit.ci] auto fixes from pre-commit.com hooks
- `4a5b6e5`: add sync test too
- `f5c9d36`: update changelog wording