### PR TITLE
:bookmark: bump version 0.8.0 -> 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.9.0]
+
 ### Changed
 
 - Changed `installation_repositories` internal event handlers to automatically create missing `Installation` models using new `(a)get_or_create_from_event` method, eliminating the need for manual import when connecting to pre-existing GitHub App installations.
@@ -123,7 +125,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-github-app/compare/v0.8.0...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-github-app/compare/v0.9.0...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.1.0
 [0.2.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.2.0
 [0.2.1]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.2.1
@@ -134,3 +136,4 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [0.6.1]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.6.1
 [0.7.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.7.0
 [0.8.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.8.0
+[0.9.0]: https://github.com/joshuadavidthomas/django-github-app/releases/tag/v0.9.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ Source = "https://github.com/joshuadavidthomas/django-github-app"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.8.0"
+current_version = "0.9.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_github_app/__init__.py
+++ b/src/django_github_app/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_github_app import __version__
 
 
 def test_version():
-    assert __version__ == "0.8.0"
+    assert __version__ == "0.9.0"


### PR DESCRIPTION
- `1cd07e1`: Clarify new/existing GitHub App installation documentation (#99)
- `d729859`: add `(a)get_or_create_from_event` method to `Installation` manager (#101)